### PR TITLE
Automatic update of Cirrious.FluentLayout to 2.8.0

### DIFF
--- a/MBAutoComplete/MBAutoComplete.csproj
+++ b/MBAutoComplete/MBAutoComplete.csproj
@@ -32,13 +32,14 @@
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cirrious.FluentLayouts.Touch, Version=2.6.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Cirrious.FluentLayout.2.8.0\lib\Xamarin.iOS10\Cirrious.FluentLayouts.Touch.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Cirrious.FluentLayouts.Touch">
-      <HintPath>..\packages\Cirrious.FluentLayout.2.5.0\lib\Xamarin.iOS10\Cirrious.FluentLayouts.Touch.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/MBAutoComplete/packages.config
+++ b/MBAutoComplete/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cirrious.FluentLayout" version="2.5.0" targetFramework="xamarinios10" />
+  <package id="Cirrious.FluentLayout" version="2.8.0" targetFramework="xamarinios10" />
 </packages>

--- a/Sample/SampleTableViewController/SampleTableViewController.csproj
+++ b/Sample/SampleTableViewController/SampleTableViewController.csproj
@@ -34,7 +34,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -51,7 +52,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -87,13 +89,14 @@
     <MtouchTlsProvider>Default</MtouchTlsProvider>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cirrious.FluentLayouts.Touch, Version=2.6.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Cirrious.FluentLayout.2.8.0\lib\Xamarin.iOS10\Cirrious.FluentLayouts.Touch.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Cirrious.FluentLayouts.Touch">
-      <HintPath>..\..\packages\Cirrious.FluentLayout.2.5.0\lib\Xamarin.iOS10\Cirrious.FluentLayouts.Touch.dll</HintPath>
-    </Reference>
     <Reference Include="MBAutoComplete">
       <HintPath>..\..\packages\MBAutoComplete.0.8.3\lib\Xamarin.iOS10\MBAutoComplete.dll</HintPath>
     </Reference>

--- a/Sample/SampleTableViewController/packages.config
+++ b/Sample/SampleTableViewController/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cirrious.FluentLayout" version="2.5.0" targetFramework="xamarinios10" />
+  <package id="Cirrious.FluentLayout" version="2.8.0" targetFramework="xamarinios10" />
   <package id="MBAutoComplete" version="0.8.3" targetFramework="xamarinios10" />
 </packages>

--- a/Sample/SampleViewController/SampleViewController.csproj
+++ b/Sample/SampleViewController/SampleViewController.csproj
@@ -34,7 +34,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -51,7 +52,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-    <DefineConstants></DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -87,13 +89,14 @@
     <MtouchTlsProvider>Default</MtouchTlsProvider>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cirrious.FluentLayouts.Touch, Version=2.6.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Cirrious.FluentLayout.2.8.0\lib\Xamarin.iOS10\Cirrious.FluentLayouts.Touch.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Cirrious.FluentLayouts.Touch">
-      <HintPath>..\..\packages\Cirrious.FluentLayout.2.5.0\lib\Xamarin.iOS10\Cirrious.FluentLayouts.Touch.dll</HintPath>
-    </Reference>
     <Reference Include="MBAutoComplete">
       <HintPath>..\..\packages\MBAutoComplete.0.8.3\lib\Xamarin.iOS10\MBAutoComplete.dll</HintPath>
     </Reference>

--- a/Sample/SampleViewController/packages.config
+++ b/Sample/SampleViewController/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cirrious.FluentLayout" version="2.5.0" targetFramework="xamarinios10" />
+  <package id="Cirrious.FluentLayout" version="2.8.0" targetFramework="xamarinios10" />
   <package id="MBAutoComplete" version="0.8.3" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Cirrious.FluentLayout` to `2.8.0` from `2.5.0`
`Cirrious.FluentLayout 2.8.0` was published at `2018-10-30T22:38:42Z`, 14 days ago

3 project updates:
Updated `MBAutoComplete\packages.config` to `Cirrious.FluentLayout` `2.8.0` from `2.5.0`
Updated `Sample\SampleTableViewController\packages.config` to `Cirrious.FluentLayout` `2.8.0` from `2.5.0`
Updated `Sample\SampleViewController\packages.config` to `Cirrious.FluentLayout` `2.8.0` from `2.5.0`

[Cirrious.FluentLayout 2.8.0 on NuGet.org](https://www.nuget.org/packages/Cirrious.FluentLayout/2.8.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
