### PR TITLE
Added missing constructors

### DIFF
--- a/MBAutoComplete/Default/DefaultDataFetcher.cs
+++ b/MBAutoComplete/Default/DefaultDataFetcher.cs
@@ -16,7 +16,7 @@ namespace MBAutoComplete
 		public Task PerformFetch(MBAutoCompleteTextField textfield, Action<ICollection<string>> completionHandler)
 		{
 			completionHandler(_unsortedData);
-            return Task.CompletedTask;
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/MBAutoComplete/Default/DefaultDataFetcher.cs
+++ b/MBAutoComplete/Default/DefaultDataFetcher.cs
@@ -13,9 +13,10 @@ namespace MBAutoComplete
 			_unsortedData = unsortedData;
 		}
 
-		public async Task PerformFetch(MBAutoCompleteTextField textfield, Action<ICollection<string>> completionHandler)
+		public Task PerformFetch(MBAutoCompleteTextField textfield, Action<ICollection<string>> completionHandler)
 		{
 			completionHandler(_unsortedData);
+            return Task.CompletedTask;
 		}
 	}
 }

--- a/MBAutoComplete/MBAutoCompleteTextField.cs
+++ b/MBAutoComplete/MBAutoCompleteTextField.cs
@@ -64,15 +64,15 @@ namespace MBAutoComplete
 
 		public MBAutoCompleteTextField() {}
 
-        public MBAutoCompleteTextField(IntPtr ptr) : base(ptr){}
+		public MBAutoCompleteTextField(IntPtr ptr) : base(ptr){}
 
-        public MBAutoCompleteTextField(CGRect frame) : base(frame){}
+		public MBAutoCompleteTextField(CGRect frame) : base(frame){}
 
-        public MBAutoCompleteTextField(NSCoder coder) : base(coder){}
+		public MBAutoCompleteTextField(NSCoder coder) : base(coder){}
 
-        public MBAutoCompleteTextField(NSObjectFlag t) : base(t){}
+		public MBAutoCompleteTextField(NSObjectFlag t) : base(t){}
 
-        public void Setup(UIViewController view, IList<string> suggestions)
+		public void Setup(UIViewController view, IList<string> suggestions)
 		{
 			_parentViewController = view;
 			DataFetcher  = new DefaultDataFetcher(suggestions);

--- a/MBAutoComplete/MBAutoCompleteTextField.cs
+++ b/MBAutoComplete/MBAutoCompleteTextField.cs
@@ -62,9 +62,17 @@ namespace MBAutoComplete
 		private bool _parentTableViewBounces = false;
 		private bool _parentTableViewAllowsSelection = false;
 
-		public MBAutoCompleteTextField(IntPtr ptr) : base(ptr){}
+		public MBAutoCompleteTextField() {}
 
-		public void Setup(UIViewController view, IList<string> suggestions)
+        public MBAutoCompleteTextField(IntPtr ptr) : base(ptr){}
+
+        public MBAutoCompleteTextField(CGRect frame) : base(frame){}
+
+        public MBAutoCompleteTextField(NSCoder coder) : base(coder){}
+
+        public MBAutoCompleteTextField(NSObjectFlag t) : base(t){}
+
+        public void Setup(UIViewController view, IList<string> suggestions)
 		{
 			_parentViewController = view;
 			DataFetcher  = new DefaultDataFetcher(suggestions);


### PR DESCRIPTION
Constructors that are defined on UITextField were added to MBAutoCompleteTextField. I needed the parameterless one to be able to construct the control programatically (i.e. not from a xib), but it shouldn't harm to add all the other ones as well.